### PR TITLE
# playwright-python/issues/2775

### DIFF
--- a/playwright/_impl/_helper.py
+++ b/playwright/_impl/_helper.py
@@ -442,6 +442,13 @@ def is_file_payload(value: Optional[Any]) -> bool:
     )
 
 
+def is_file_array_payload(value: Optional[Any]) -> bool:
+    return (
+        isinstance(value, list)
+        and all(is_file_payload(x) for x in value)
+    )
+
+
 TEXTUAL_MIME_TYPE = re.compile(
     r"^(text\/.*?|application\/(json|(x-)?javascript|xml.*?|ecmascript|graphql|x-www-form-urlencoded)|image\/svg(\+xml)?|application\/.*?(\+json|\+xml))(;\s*charset=.*)?$"
 )


### PR DESCRIPTION
Allows for multiple files to be sent under a single field in an APIRequestContext request